### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md


### PR DESCRIPTION
Include missing files in sdist for #2

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.BmWneVEroP
+ trap 'rm -rf /tmp/tmp.BmWneVEroP' EXIT
+ python -m venv /tmp/tmp.BmWneVEroP
+ python setup.py sdist -d /tmp/tmp.BmWneVEroP
running sdist
running egg_info
writing pubdoc.egg-info/PKG-INFO
writing dependency_links to pubdoc.egg-info/dependency_links.txt
writing entry points to pubdoc.egg-info/entry_points.txt
writing requirements to pubdoc.egg-info/requires.txt
writing top-level names to pubdoc.egg-info/top_level.txt
reading manifest file 'pubdoc.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pubdoc.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

running check
creating pubdoc-0.5.2
creating pubdoc-0.5.2/pubdoc
creating pubdoc-0.5.2/pubdoc.egg-info
creating pubdoc-0.5.2/pubdoc/publishers
copying files to pubdoc-0.5.2...
copying MANIFEST.in -> pubdoc-0.5.2
copying readme.md -> pubdoc-0.5.2
copying setup.py -> pubdoc-0.5.2
copying pubdoc/__init__.py -> pubdoc-0.5.2/pubdoc
copying pubdoc/__main__.py -> pubdoc-0.5.2/pubdoc
copying pubdoc/__version__.py -> pubdoc-0.5.2/pubdoc
copying pubdoc/app.py -> pubdoc-0.5.2/pubdoc
copying pubdoc/pubdoc.py -> pubdoc-0.5.2/pubdoc
copying pubdoc.egg-info/PKG-INFO -> pubdoc-0.5.2/pubdoc.egg-info
copying pubdoc.egg-info/SOURCES.txt -> pubdoc-0.5.2/pubdoc.egg-info
copying pubdoc.egg-info/dependency_links.txt -> pubdoc-0.5.2/pubdoc.egg-info
copying pubdoc.egg-info/entry_points.txt -> pubdoc-0.5.2/pubdoc.egg-info
copying pubdoc.egg-info/requires.txt -> pubdoc-0.5.2/pubdoc.egg-info
copying pubdoc.egg-info/top_level.txt -> pubdoc-0.5.2/pubdoc.egg-info
copying pubdoc/publishers/__init__.py -> pubdoc-0.5.2/pubdoc/publishers
copying pubdoc/publishers/dokuwiki.py -> pubdoc-0.5.2/pubdoc/publishers
Writing pubdoc-0.5.2/setup.cfg
Creating tar archive
removing 'pubdoc-0.5.2' (and everything under it)
+ cd /
+ /tmp/tmp.BmWneVEroP/bin/pip install /tmp/tmp.BmWneVEroP/pubdoc-0.5.2.tar.gz
Processing /tmp/tmp.BmWneVEroP/pubdoc-0.5.2.tar.gz
Collecting Click>=7.0 (from pubdoc==0.5.2)
  Using cached https://files.pythonhosted.org/packages/d2/3d/fa76db83bf75c4f8d338c2fd15c8d33fdd7ad23a9b5e57eb6c5de26b430e/click-7.1.2-py2.py3-none-any.whl
Collecting dokuwiki==1.2.1 (from pubdoc==0.5.2)
  Downloading https://files.pythonhosted.org/packages/a4/03/068bf36de5f446440acbf022a9d950886631a64119b823c5c30ee26f8fcb/dokuwiki-1.2.1-py3-none-any.whl
Collecting pprint==0.1 (from pubdoc==0.5.2)
  Downloading https://files.pythonhosted.org/packages/99/12/b6383259ef85c2b942ab9135f322c0dce83fdca8600d87122d2b0181451f/pprint-0.1.tar.gz
Installing collected packages: Click, dokuwiki, pprint, pubdoc
  Running setup.py install for pprint: started
    Running setup.py install for pprint: finished with status 'done'
  Running setup.py install for pubdoc: started
    Running setup.py install for pubdoc: finished with status 'done'
Successfully installed Click-7.1.2 dokuwiki-1.2.1 pprint-0.1 pubdoc-0.5.2
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.BmWneVEroP
```
